### PR TITLE
Add cross-database compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dbt_packages/
 profiles.yml
 .venv
 .user.yml
+.data/

--- a/macros/cross_database_utils/try_to_cast_date.sql
+++ b/macros/cross_database_utils/try_to_cast_date.sql
@@ -1,0 +1,106 @@
+{#
+
+    This macro takes in a date column and date format (defaults to 'YYYY-MM-DD')
+    then runs a try-to-cast based on the adapter type. Returns NULL casted as
+    date if the try-to-cast fails.
+
+    Supported date_format values: 'YYYY-MM-DD', 'YYYYMMDD', 'MM/DD/YYYY',
+    'YYYY-MM-DD HH:MI:SS'.
+
+#}
+
+{%- macro try_to_cast_date(column_name, date_format='YYYY-MM-DD') -%}
+
+    {{ return(adapter.dispatch('try_to_cast_date')(column_name, date_format)) }}
+
+{%- endmacro -%}
+
+{%- macro bigquery__try_to_cast_date(column_name, date_format) -%}
+
+    {%- if date_format == 'YYYY-MM-DD HH:MI:SS' -%}
+    safe_cast( date( {{ column_name }} ) as date )
+    {%- else -%}
+    safe_cast( {{ column_name }} as date )
+    {%- endif -%}
+
+{%- endmacro -%}
+
+{%- macro default__try_to_cast_date(column_name, date_format) -%}
+
+    try_cast( {{ column_name }} as date )
+
+{%- endmacro -%}
+
+{#
+    DuckDB's try_cast(varchar as date) only accepts ISO 'YYYY-MM-DD', so
+    format-specific strings (e.g. NPPES 'MM/DD/YYYY') would silently become NULL.
+    Use try_strptime with the matching format tokens, then cast to date.
+    Cast the input to varchar first so an already-typed column can't raise;
+    a value that doesn't match the format yields NULL (try semantics).
+#}
+{%- macro duckdb__try_to_cast_date(column_name, date_format) -%}
+
+    {%- if date_format == 'YYYY-MM-DD' -%}
+    try_strptime( cast( {{ column_name }} as varchar ), '%Y-%m-%d' )::date
+    {%- elif date_format == 'YYYYMMDD' -%}
+    try_strptime( cast( {{ column_name }} as varchar ), '%Y%m%d' )::date
+    {%- elif date_format == 'MM/DD/YYYY' -%}
+    try_strptime( cast( {{ column_name }} as varchar ), '%m/%d/%Y' )::date
+    {%- elif date_format == 'YYYY-MM-DD HH:MI:SS' -%}
+    try_strptime( cast( {{ column_name }} as varchar ), '%Y-%m-%d %H:%M:%S' )::date
+    {%- else -%}
+    try_cast( {{ column_name }} as date )
+    {%- endif -%}
+
+{%- endmacro -%}
+
+{%- macro postgres__try_to_cast_date(column_name, date_format) -%}
+
+    {{ dbt.safe_cast(column_name, api.Column.translate_type("date")).strip() }}
+
+{%- endmacro -%}
+
+{%- macro redshift__try_to_cast_date(column_name, date_format) -%}
+
+    {%- if date_format == 'YYYY-MM-DD' -%}
+    case
+      when {{ column_name }} similar to '\\d{4}-\\d{2}-\\d{2}'
+      then to_date( {{ column_name }}, 'YYYY-MM-DD')
+      else date(NULL)
+    end
+    {%- elif date_format == 'YYYYMMDD' -%}
+    case
+      when {{ column_name }} similar to '\\d{4}\\d{2}\\d{2}'
+      then to_date( {{ column_name }}, 'YYYYMMDD')
+      else date(NULL)
+    end
+    {%- elif date_format == 'MM/DD/YYYY' -%}
+    case
+      when {{ column_name }} similar to '\\d{2}/\\d{2}/\\d{4}'
+      then to_date( {{ column_name }}, 'MM/DD/YYYY')
+      else date(NULL)
+    end
+    {%- elif date_format == 'YYYY-MM-DD HH:MI:SS' -%}
+    case
+      when {{ column_name }} similar to '\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}'
+      then to_date( {{ column_name }}, 'YYYY-MM-DD HH:MI:SS')
+      else date(NULL)
+    end
+    {%- else -%}
+    date(NULL)
+    {%- endif -%}
+
+{%- endmacro -%}
+
+{%- macro snowflake__try_to_cast_date(column_name, date_format) -%}
+
+    try_to_date(to_varchar({{ column_name }}))
+
+{%- endmacro -%}
+
+{%- macro athena__try_to_cast_date(column_name, date_format) -%}
+    (case
+        when typeof({{ column_name }}) = 'date' then date({{ column_name }})
+        else try_cast(substring(try_cast({{ column_name }} as varchar), 1, 10) as date)
+    end)
+{%- endmacro -%}

--- a/models/final/provider.sql
+++ b/models/final/provider.sql
@@ -105,24 +105,24 @@ select
         end as entity_type_description
     , primary_taxonomy.taxonomy_code as primary_taxonomy_code
     , primary_taxonomy.description as primary_specialty_description
-    , initcap(npi_expanded.provider_first_name) as provider_first_name
-    , initcap(npi_expanded.provider_last_name) as provider_last_name
+    , npi_expanded.provider_first_name as provider_first_name
+    , npi_expanded.provider_last_name as provider_last_name
     , npi_expanded.provider_credential_text as provider_credential
-    , initcap(npi_expanded.provider_organization_name) as provider_organization_name
-    , initcap(npi_expanded.provider_other_organization_name) as provider_other_organization_name
+    , npi_expanded.provider_organization_name as provider_organization_name
+    , npi_expanded.provider_other_organization_name as provider_other_organization_name
     , npi_expanded.provider_other_organization_name_type_code as provider_other_organization_name_type_code
     , npi_expanded.provider_other_organization_name_type_description as provider_other_organization_name_type_description
-    , initcap(npi_expanded.parent_organization_lbn) as parent_organization_name
-    , initcap(npi_expanded.provider_first_line_business_practice_location_address) as practice_address_line_1
-    , initcap(npi_expanded.provider_second_line_business_practice_location_address) as practice_address_line_2
-    , initcap(npi_expanded.provider_business_practice_location_address_city_name) as practice_city
+    , npi_expanded.parent_organization_lbn as parent_organization_name
+    , npi_expanded.provider_first_line_business_practice_location_address as practice_address_line_1
+    , npi_expanded.provider_second_line_business_practice_location_address as practice_address_line_2
+    , npi_expanded.provider_business_practice_location_address_city_name as practice_city
     , npi_expanded.provider_business_practice_location_address_state_name as practice_state
     , npi_expanded.provider_business_practice_location_address_postal_code as practice_zip_code
     , npi_expanded.provider_business_mailing_address_telephone_number as mailing_telephone_number
     , npi_expanded.provider_business_practice_location_address_telephone_number as location_telephone_number
     , npi_expanded.authorized_official_telephone_number as official_telephone_number
-    , cast(last_update_date as date) as last_updated
-    , cast(npi_deactivation_date as date) as deactivation_date
+    , {{ try_to_cast_date('last_update_date', 'MM/DD/YYYY') }} as last_updated
+    , {{ try_to_cast_date('npi_deactivation_date', 'MM/DD/YYYY') }} as deactivation_date
     , case
         when npi_deactivation_date is not null then 1
         else 0

--- a/models/final/taxonomy_unpivot.sql
+++ b/models/final/taxonomy_unpivot.sql
@@ -1,84 +1,50 @@
-with npi_source as (
+/*
+    Unpivots the 15 wide taxonomy code/switch column pairs into one row per
+    (npi, taxonomy slot).
 
-        select
-              npi
-            , healthcare_provider_taxonomy_code_1
-            , healthcare_provider_primary_taxonomy_switch_1
-            , healthcare_provider_taxonomy_code_2
-            , healthcare_provider_primary_taxonomy_switch_2
-            , healthcare_provider_taxonomy_code_3
-            , healthcare_provider_primary_taxonomy_switch_3
-            , healthcare_provider_taxonomy_code_4
-            , healthcare_provider_primary_taxonomy_switch_4
-            , healthcare_provider_taxonomy_code_5
-            , healthcare_provider_primary_taxonomy_switch_5
-            , healthcare_provider_taxonomy_code_6
-            , healthcare_provider_primary_taxonomy_switch_6
-            , healthcare_provider_taxonomy_code_7
-            , healthcare_provider_primary_taxonomy_switch_7
-            , healthcare_provider_taxonomy_code_8
-            , healthcare_provider_primary_taxonomy_switch_8
-            , healthcare_provider_taxonomy_code_9
-            , healthcare_provider_primary_taxonomy_switch_9
-            , healthcare_provider_taxonomy_code_10
-            , healthcare_provider_primary_taxonomy_switch_10
-            , healthcare_provider_taxonomy_code_11
-            , healthcare_provider_primary_taxonomy_switch_11
-            , healthcare_provider_taxonomy_code_12
-            , healthcare_provider_primary_taxonomy_switch_12
-            , healthcare_provider_taxonomy_code_13
-            , healthcare_provider_primary_taxonomy_switch_13
-            , healthcare_provider_taxonomy_code_14
-            , healthcare_provider_primary_taxonomy_switch_14
-            , healthcare_provider_taxonomy_code_15
-            , healthcare_provider_primary_taxonomy_switch_15
-        from {{ source('nppes', 'npi') }}
+    dbt_utils.unpivot only unpivots a single value column set, so the paired
+    code + switch columns are unpivoted separately (from the int_provider_taxonomy_*
+    staging models) and rejoined on the numeric slot suffix. This keeps the model
+    cross-database compatible (Snowflake / Postgres / Redshift / DuckDB).
 
-),
+    cast_to uses dbt.type_string() so the string type resolves per adapter
+    (varchar / string / text) — no per-warehouse edits needed.
+*/
 
-unpivot as (
+with codes as (
 
-    select *
-    from npi_source
-    /* unpivot taxonomy code */
-    unpivot(taxonomy_code for taxonomy_col in (   healthcare_provider_taxonomy_code_1
-                                                , healthcare_provider_taxonomy_code_2
-                                                , healthcare_provider_taxonomy_code_3
-                                                , healthcare_provider_taxonomy_code_4
-                                                , healthcare_provider_taxonomy_code_5
-                                                , healthcare_provider_taxonomy_code_6
-                                                , healthcare_provider_taxonomy_code_7
-                                                , healthcare_provider_taxonomy_code_8
-                                                , healthcare_provider_taxonomy_code_9
-                                                , healthcare_provider_taxonomy_code_10
-                                                , healthcare_provider_taxonomy_code_11
-                                                , healthcare_provider_taxonomy_code_12
-                                                , healthcare_provider_taxonomy_code_13
-                                                , healthcare_provider_taxonomy_code_14
-                                                , healthcare_provider_taxonomy_code_15
-                                              )
-    )
-    /* unpivot primary indicator for each taxonomy */
-    unpivot(taxonomy_switch for switch_col in (   healthcare_provider_primary_taxonomy_switch_1
-                                                , healthcare_provider_primary_taxonomy_switch_2
-                                                , healthcare_provider_primary_taxonomy_switch_3
-                                                , healthcare_provider_primary_taxonomy_switch_4
-                                                , healthcare_provider_primary_taxonomy_switch_5
-                                                , healthcare_provider_primary_taxonomy_switch_6
-                                                , healthcare_provider_primary_taxonomy_switch_7
-                                                , healthcare_provider_primary_taxonomy_switch_8
-                                                , healthcare_provider_primary_taxonomy_switch_9
-                                                , healthcare_provider_primary_taxonomy_switch_10
-                                                , healthcare_provider_primary_taxonomy_switch_11
-                                                , healthcare_provider_primary_taxonomy_switch_12
-                                                , healthcare_provider_primary_taxonomy_switch_13
-                                                , healthcare_provider_primary_taxonomy_switch_14
-                                                , healthcare_provider_primary_taxonomy_switch_15
-                                              )
-    )
-    /* join each taxonomy with its primary indicator */
-    where regexp_replace(taxonomy_col,'[^[:digit:]]','') = regexp_replace(switch_col,'[^[:digit:]]','')
+    {{ dbt_utils.unpivot(
+        relation=ref('int_provider_taxonomy_codes'),
+        cast_to=dbt.type_string(),
+        exclude=['npi'],
+        field_name='taxonomy_col',
+        value_name='taxonomy_code'
+    ) }}
 
 )
 
-select * from unpivot
+, switches as (
+
+    {{ dbt_utils.unpivot(
+        relation=ref('int_provider_taxonomy_switches'),
+        cast_to=dbt.type_string(),
+        exclude=['npi'],
+        field_name='switch_col',
+        value_name='taxonomy_switch'
+    ) }}
+
+)
+
+select
+      codes.npi
+    , upper(codes.taxonomy_col) as taxonomy_col
+    , codes.taxonomy_code
+    , upper(switches.switch_col) as switch_col
+    , switches.taxonomy_switch
+from codes
+inner join switches
+    on codes.npi = switches.npi
+    /* pair code_N with switch_N by the trailing slot number */
+    and replace(codes.taxonomy_col, 'healthcare_provider_taxonomy_code_', '')
+        = replace(switches.switch_col, 'healthcare_provider_primary_taxonomy_switch_', '')
+where codes.taxonomy_code is not null

--- a/models/intermediate/int_provider_taxonomy_codes.sql
+++ b/models/intermediate/int_provider_taxonomy_codes.sql
@@ -1,0 +1,27 @@
+/*
+    Staging model feeding dbt_utils.unpivot in taxonomy_unpivot.
+    Isolates npi + the 15 taxonomy CODE columns so the macro can be
+    pointed at a relation whose only unpivot targets are the codes.
+    Materialized as a view (dbt_utils.unpivot introspects the relation's
+    columns, so it cannot run against an ephemeral model).
+*/
+{{ config(materialized='view') }}
+
+select
+      npi
+    , healthcare_provider_taxonomy_code_1
+    , healthcare_provider_taxonomy_code_2
+    , healthcare_provider_taxonomy_code_3
+    , healthcare_provider_taxonomy_code_4
+    , healthcare_provider_taxonomy_code_5
+    , healthcare_provider_taxonomy_code_6
+    , healthcare_provider_taxonomy_code_7
+    , healthcare_provider_taxonomy_code_8
+    , healthcare_provider_taxonomy_code_9
+    , healthcare_provider_taxonomy_code_10
+    , healthcare_provider_taxonomy_code_11
+    , healthcare_provider_taxonomy_code_12
+    , healthcare_provider_taxonomy_code_13
+    , healthcare_provider_taxonomy_code_14
+    , healthcare_provider_taxonomy_code_15
+from {{ source('nppes', 'npi') }}

--- a/models/intermediate/int_provider_taxonomy_switches.sql
+++ b/models/intermediate/int_provider_taxonomy_switches.sql
@@ -1,0 +1,27 @@
+/*
+    Staging model feeding dbt_utils.unpivot in taxonomy_unpivot.
+    Isolates npi + the 15 primary-taxonomy SWITCH columns so the macro can be
+    pointed at a relation whose only unpivot targets are the switches.
+    Materialized as a view (dbt_utils.unpivot introspects the relation's
+    columns, so it cannot run against an ephemeral model).
+*/
+{{ config(materialized='view') }}
+
+select
+      npi
+    , healthcare_provider_primary_taxonomy_switch_1
+    , healthcare_provider_primary_taxonomy_switch_2
+    , healthcare_provider_primary_taxonomy_switch_3
+    , healthcare_provider_primary_taxonomy_switch_4
+    , healthcare_provider_primary_taxonomy_switch_5
+    , healthcare_provider_primary_taxonomy_switch_6
+    , healthcare_provider_primary_taxonomy_switch_7
+    , healthcare_provider_primary_taxonomy_switch_8
+    , healthcare_provider_primary_taxonomy_switch_9
+    , healthcare_provider_primary_taxonomy_switch_10
+    , healthcare_provider_primary_taxonomy_switch_11
+    , healthcare_provider_primary_taxonomy_switch_12
+    , healthcare_provider_primary_taxonomy_switch_13
+    , healthcare_provider_primary_taxonomy_switch_14
+    , healthcare_provider_primary_taxonomy_switch_15
+from {{ source('nppes', 'npi') }}

--- a/models/intermediate/specialty_mapping.sql
+++ b/models/intermediate/specialty_mapping.sql
@@ -24,8 +24,7 @@ medicare_add_row_num as (
         , medicare_provider_supplier_type_description
         , row_number() over (
             partition by provider_taxonomy_code
-            /* using try_cast since some codes are alphanumeric */
-            order by try_cast(medicare_specialty_code as number) desc
+            order by medicare_specialty_code desc
         ) as row_num
     from medicare
     where provider_taxonomy_code is not null

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: [">=1.0.0", "<2.0.0"]


### PR DESCRIPTION
# What's changed

Makes the dbt models warehouse-agnostic.

- `macros/cross_database_utils/try_to_cast_date.sql` (new) — adapter-dispatched parse-and-cast-to-date with try/safe semantics, modeled on the Tuva macro of the same name. Adds a DuckDB implementation (try_strptime(cast(col as varchar), '%m/%d/%Y')::date) so NPPES MM/DD/YYYY strings parse correctly instead of silently becoming NULL under the default try_cast.
- `models/final/provider.sql` — parse last_update_date / npi_deactivation_date via try_to_cast_date(..., 'MM/DD/YYYY'); removed initcap() wrapping on name/address fields (behavior varies by warehouse).
- `models/final/taxonomy_unpivot.sql` — replaced Snowflake-native UNPIVOTs with two dbt_utils.unpivot calls rejoined on the slot suffix; cast_to=dbt.type_string() for portable typing.
- `models/intermediate/int_provider_taxonomy_{codes,switches}.sql` (new) — staging views feeding the two unpivots. The dbt_utils.unpivot macro requires a model reference.
- `models/intermediate/specialty_mapping.sql` — dropped Snowflake-native try_cast(... as number) in the row_number() ordering. Manually checked results and did not find this necessary.
- `packages.yml` (new) — add dbt_utils (>=1.0.0,<2.0.0).

# Testing

- DuckDB date parsing verified: MM/DD/YYYY → date; empty / invalid / NULL → NULL.
- Ran `dbt deps && dbt build` in DuckDB. Confirmed final count matches unique count. No duplicates were added with new unpivot logic.
<img width="636" height="248" alt="image" src="https://github.com/user-attachments/assets/67d26695-1d25-4aba-a3c9-bdd15d467839" />